### PR TITLE
Lock statsd backend versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update add git && \
     git clone https://github.com/etsy/statsd.git && \
     cd statsd && git reset --hard v0.7.2 && \
     apk del git && \
-    npm install statsd-librato-backend statsd-datadog-backend
+    npm install statsd-librato-backend@0.1.7 statsd-datadog-backend@0.1.0
 
 WORKDIR /root/statsd
 


### PR DESCRIPTION
First, I confirmed the issue @maxjacobson reported last night by sending a metric:

```
$ docker run --rm -p 8125:8125/udp -v ~/Code/codeclimate/toolbox/clusters/cc-prod-nexus/etc/statsd.js:/etc/config.js codeclimate/statsd

24 Mar 13:45:47 - reading config file: /etc/config.js
(node:1) DeprecationWarning: process.EventEmitter is deprecated. Use require('events') instead.
24 Mar 13:45:47 - server is up
24 Mar 13:45:47 - DEBUG: Loading backend: statsd-librato-backend
24 Mar 13:46:47 - DEBUG: Sending Payload: {"time":1490363160,"tags":{"host":"1ba0e3008887"},"measurements":[{"name":"npc.test","value":1,"tags":{}},{"name":"npc.test","value":1,"tags":{}}]}
24 Mar 13:46:47 - LOG_ERR: Failed to post to Librato: HTTP 403: {"errors":["Tag based measurements are not enabled for this account. Contact support@librato.com for more information"]}
```

Then, I fixed the versions and sent a metric, which emitted to Librato successfully.

```
$ docker run --rm -p 8125:8125/udp -v ~/Code/codeclimate/toolbox/clusters/cc-prod-nexus/etc/statsd.js:/etc/config.js codeclimate/statsd

24 Mar 13:53:34 - reading config file: /etc/config.js
(node:1) DeprecationWarning: process.EventEmitter is deprecated. Use require('events') instead.
24 Mar 13:53:34 - server is up
24 Mar 13:53:34 - DEBUG: Loading backend: statsd-librato-backend
```

![image](https://cloud.githubusercontent.com/assets/1634280/24298399/4a4e07cc-107c-11e7-9c44-d1321cef30a4.png)