### PR TITLE
Add cloudwatch backend library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ RUN apk --update add git && \
     git clone https://github.com/etsy/statsd.git && \
     cd statsd && git reset --hard v0.7.2 && \
     apk del git && \
-    npm install statsd-librato-backend@0.1.7 statsd-datadog-backend@0.1.0
+    npm install \
+      aws-cloudwatch-statsd-backend@1.2.0 \
+      statsd-librato-backend@0.1.7 \
+      statsd-datadog-backend@0.1.0
+
 
 WORKDIR /root/statsd
 


### PR DESCRIPTION
I started looking (again) at emiting some metrics to CloudWatch for autoscaling
purposes. This library [supports whitelisting metrics][1], which would allow us
to emit certain metrics to CloudWatch for autoscaling purpose without spending a
lot of money on other metrics we don't care about in AWS.

This addition won't actually start using this yet: I'll be adding config to `toolbox` to try this out after the image itself is updated.

[1]: https://github.com/camitz/aws-cloudwatch-statsd-backend#whitelisting-metrics