### PR TITLE
Lock cloudwatch backend by SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ WORKDIR /root/
 RUN apk --update add git && \
     git clone https://github.com/etsy/statsd.git && \
     cd statsd && git reset --hard v0.7.2 && \
-    apk del git && \
     npm install \
-      aws-cloudwatch-statsd-backend@1.2.0 \
+      camitz/aws-cloudwatch-statsd-backend#abd4ff3 \
       statsd-librato-backend@0.1.7 \
-      statsd-datadog-backend@0.1.0
+      statsd-datadog-backend@0.1.0 && \
+    apk del git
 
 
 WORKDIR /root/statsd


### PR DESCRIPTION
This backend library has had some recent updates that make the usage pattern we
want feasible, but a new official version hasn't yet been released, and
the internal version in the `package.json` hasn't been updated either.

This led to some confusion since I installed the latest released version
& was following docs & reading code for a newer unreleased SHA.

The change here locks us to particular SHA on the master branch for now.
I've tested this by building the image & running it on a production
nexus instance on a on-standard port & sending messages to it with `nc`.
The metric appeared in cloudwatch as desired when I did this.