### PR TITLE
Update `aws-cloudwatch-statsd-backend`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update add git && \
     git clone https://github.com/etsy/statsd.git && \
     cd statsd && git reset --hard v0.7.2 && \
     npm install \
-      codeclimate/aws-cloudwatch-statsd-backend#a3981840 \
+      codeclimate/aws-cloudwatch-statsd-backend#7ad511db \
       statsd-librato-backend@0.1.7 \
       statsd-datadog-backend@0.1.0 && \
     apk del git


### PR DESCRIPTION
Pointing this to: https://github.com/codeclimate/aws-cloudwatch-statsd-backend/commit/7ad511db65cfbaa48036345f8c6c33294acd285d so we can take advantage of an `aws-sdk` version bump.